### PR TITLE
Get sandboxes older than 24h

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -22,6 +22,10 @@ student_name: >-
   | default(babylon_username)
   | default('babylon') }}
 
+# minimum age the sandbox must be before it's selected from the pool
+# default is 24h
+babylon_aws_sandbox_min_age: "{{ 3600 * 24 }}"
+
 # Variables from secret via the aws_sandbox_manager variable
 pool_table: "{{ aws_sandbox_manager.pool_table | default('accounts') }}"
 pool_region: "{{ aws_sandbox_manager.pool_region | default('us-east-1') }}"

--- a/tasks/get.yaml
+++ b/tasks/get.yaml
@@ -64,7 +64,7 @@
 
         - name: Get first available sandboxes older than 24h
           vars:
-            _yesterday: "{{ ansible_date_time.epoch | int  - 3600 * 24 }}"
+            _yesterday: "{{ ansible_date_time.epoch | int  - babylon_aws_sandbox_min_age }}"
           command: >-
             aws
             --region {{ pool_region }}

--- a/tasks/get.yaml
+++ b/tasks/get.yaml
@@ -57,22 +57,67 @@
 
     - when: query1.Count == 0
       block:
-        - name: Get first free sandboxes
+        - name: Gather facts for ansible_date_time
+          setup:
+            filter: ansible_date_time
+            gather_subset: min
+
+        - name: Get first available sandboxes older than 24h
+          vars:
+            _yesterday: "{{ ansible_date_time.epoch | int  - 3600 * 24 }}"
           command: >-
             aws
             --region {{ pool_region }}
             dynamodb scan
             --table-name {{ pool_table }}
-            --filter-expression 'available = :a and attribute_exists(aws_access_key_id) and attribute_exists(aws_secret_access_key) and attribute_exists(hosted_zone_id) and attribute_exists(#Z) and attribute_exists(account_id)'
-            --expression-attribute-values '{":a":{"BOOL":true}}'
-            --expression-attribute-names '{"#Z": "zone"}'
+            --filter-expression 'available = :a
+            and #U < :b
+            and attribute_exists(aws_access_key_id)
+            and attribute_exists(aws_secret_access_key)
+            and attribute_exists(hosted_zone_id)
+            and attribute_exists(#Z)
+            and attribute_exists(account_id)'
+            --expression-attribute-values
+            '{":a":{"BOOL":true}, ":b":{"N":"{{_yesterday}}"}}'
+            --expression-attribute-names
+            '{"#Z": "zone", "#U": "aws:rep:updatetime"}'
             --max-item {{ buffer }}
           register: r_shortlist
           changed_when: false
 
+        - name: Save reply output of previous command as object
+          set_fact:
+            r_shortlist_reply: >-
+              {{ r_shortlist.stdout | from_json }}
+
+        - when: r_shortlist_reply.Count | int == 0
+          block:
+            - name: Get first available sandboxes again without 24h constraint
+              command: >-
+                aws
+                --region {{ pool_region }}
+                dynamodb scan
+                --table-name {{ pool_table }}
+                --filter-expression 'available = :a
+                and attribute_exists(aws_access_key_id)
+                and attribute_exists(aws_secret_access_key)
+                and attribute_exists(hosted_zone_id)
+                and attribute_exists(#Z)
+                and attribute_exists(account_id)'
+                --expression-attribute-values '{":a":{"BOOL":true}}'
+                --expression-attribute-names '{"#Z": "zone"}'
+                --max-item {{ buffer }}
+              register: r_shortlist_bis
+              changed_when: false
+
+            - name: Override reply output object (all available sandboxes)
+              set_fact:
+                r_shortlist_reply: "{{ r_shortlist_bis.stdout | from_json }}"
+
+
         - name: Save the list of the first free sandboxes
           set_fact:
-            sandbox_shortlist: "{{ r_shortlist.stdout | from_json | json_query('Items[*].name.S') }}"
+            sandbox_shortlist: "{{ r_shortlist_reply | json_query('Items[*].name.S') }}"
 
         - name: Get the cluster console
           k8s_info:
@@ -123,7 +168,7 @@
           register: _putaccount
 
         - debug:
-            var: r_shortlist
+            var: r_shortlist_reply
             verbosity: 2
 
         - debug:
@@ -132,8 +177,7 @@
 
         - set_fact:
             sandbox_picked: >-
-              {{ r_shortlist.stdout
-              | from_json
+              {{ r_shortlist_reply
               | json_query('Items[*]')
               | selectattr('name.S', 'equalto', _putaccount.stdout)
               | list }}

--- a/tasks/get.yaml
+++ b/tasks/get.yaml
@@ -64,7 +64,9 @@
 
         - name: Get first available sandboxes older than 24h
           vars:
-            _yesterday: "{{ ansible_date_time.epoch | int  - babylon_aws_sandbox_min_age }}"
+            _yesterday: >-
+              {{ ansible_date_time.epoch | int
+              - babylon_aws_sandbox_min_age | int }}
           command: >-
             aws
             --region {{ pool_region }}


### PR DESCRIPTION
In order to work on cost reports, make sure sandboxes older than 24 are
used when getting a sandbox from the pool.

see https://issues.redhat.com/browse/GPTEINFRA-558

#### why not just sort by last_used instead of using a condition age > 24h?
I tried to do LIFO but with dynamodb being a NOSQL database, it's
difficult.

It's not possible to create an index on a column that is a boolean, like `available`.

In order to do that, i would have to create a new column 'isAvailable',
as a string with content `"x"` and absent if not available. It would be
redundant with the current `available` BOOL column.

Then i would need to create an sparse index in dynamoDB with that primary key
`isAvailable`, with the sort key being `aws:rep:updatetime` or a new
manual field "last updated". That sparse index would then be used when
scanning or Quering the DB in order to get the result in a specific
order (sorted by last used for example).

This would imply way more work and touching other parts of the code, not
just the part that gets a new sandbox from the DB.

I suggest with start with the 24h condition when selecting and see if it's enough.