### PR TITLE
Populate uuid when booking sandbox

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -4,6 +4,9 @@ buffer: 20
 # Variables from Anarchy Subject
 guid: "{{ vars.anarchy_subject.vars.job_vars.guid | default(None) }}"
 
+# Variables from Anarchy Subject
+uuid: "{{ vars.anarchy_subject.vars.job_vars.uuid | default(None) }}"
+
 # Variables from either Governor or Subject
 env_type: >-
   {{ vars.anarchy_governor.vars.job_vars.env_type

--- a/readme.adoc
+++ b/readme.adoc
@@ -20,6 +20,12 @@ The following **input** variables are expected:
 | -
 | Yes
 
+| `uuid`
+| String
+| The UUID of the environment
+| -
+| No  (but will be)
+
 | `pool_manager_aws_access_key_id`
 | String
 | The AWS access key of an IAM user that can query the dynamodb

--- a/tasks/get.yaml
+++ b/tasks/get.yaml
@@ -14,11 +14,16 @@
           and attribute_exists(hosted_zone_id)
           and attribute_exists(#Z)
           and attribute_exists(account_id)
+          and (
+            attribute_not_exists(service_uuid) or service_uuid = :u
+          )
         _data:
           ":a":
             BOOL: false
           ":g":
             S: "{{ guid }}"
+          ":u":
+            S: "{{ uuid }}"
           ":e":
             S: "{{ env_type }}"
       command: >-
@@ -144,6 +149,8 @@
                 BOOL: true
               ":gu":
                 S: "{{ guid }}"
+              ":uu":
+                S: "{{ uuid }}"
               ":en":
                 S: "{{ env_type }}"
               ":ow":
@@ -162,6 +169,7 @@
             --update-expression
             "SET available = :av,
             guid = :gu, envtype = :en,
+            service_uuid = :uu,
             #o = :ow, owner_email = :email,
             #c = :co"
             --expression-attribute-values '{{ _data | to_json }}'

--- a/tasks/release.yaml
+++ b/tasks/release.yaml
@@ -14,11 +14,16 @@
           and attribute_exists(hosted_zone_id)
           and attribute_exists(#Z)
           and attribute_exists(account_id)
+          and (
+            attribute_not_exists(service_uuid) or service_uuid = :u
+          )
         _data:
           ":a":
             BOOL: false
           ":g":
             S: "{{ guid }}"
+          ":u":
+            S: "{{ uuid }}"
           ":e":
             S: "{{ env_type }}"
       command: >-


### PR DESCRIPTION
This change, if applied, adds uuid as service_uuid column in the DB. The goal is to transition slowly to using only uuid and not (guid, envtype)

- when fetching, use the uuid if it exists
- if service_uuid column doesn't exist, keep current behavior

see GPTEINFRA-2372